### PR TITLE
Fails to start the server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loader: 'react-hot-loader!babel-loader'
+      loaders: ['react-hot-loader/webpack', 'babel-loader']
     }]
   },
   resolve: {


### PR DESCRIPTION
Error: Module '.......\node_modules\react-hot-loader\index.js' is not a loader (must have normal or pitch function)