### PR TITLE
Remove react-hot-loader/patch entry point in webpack. Addresses #11.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 
 module.exports = {
   entry: [
-    'react-hot-loader/patch',
     './src/index.js'
   ],
   module: {


### PR DESCRIPTION
For issue #11 